### PR TITLE
fixing regex bug

### DIFF
--- a/lib/function.php
+++ b/lib/function.php
@@ -1263,7 +1263,7 @@ function xss_clean($data) {
 	#$data = preg_replace('#(<[^>]+?[\x00-\x20"\'])(?:on|xmlns)[^>]*+>#iu', '$1>', $data);
 	do {
 		$old_data	= $data;
-		$data		= preg_replace('#(<[^>]+?[\x00-\x20"\'])(on|xmlns)([^>]*+)>#iu', '$1DISABLED_$2$3>', $data);
+		$data		= preg_replace('#(<[^>\s]+?[\x00-\x20"\'])(on|xmlns)([^>]*+)>#iu', '$1DISABLED_$2$3>', $data);
 	} while ($old_data !== $data);
 
 	// Remove javascript: and vbscript: protocols

--- a/lib/function.php
+++ b/lib/function.php
@@ -1263,7 +1263,7 @@ function xss_clean($data) {
 	#$data = preg_replace('#(<[^>]+?[\x00-\x20"\'])(?:on|xmlns)[^>]*+>#iu', '$1>', $data);
 	do {
 		$old_data	= $data;
-		$data		= preg_replace('#(<[^>\s]+?[\x00-\x20"\'])(on|xmlns)([^>]*+)>#iu', '$1DISABLED_$2$3>', $data);
+		$data		= preg_replace('#(<[A-Za-z][^>]*?[\x00-\x20"\'])(on|xmlns)([^>]*+)>#iu', '$1DISABLED_$2$3>', $data);
 	} while ($old_data !== $data);
 
 	// Remove javascript: and vbscript: protocols


### PR DESCRIPTION
currently, the regex will match `<test on[...]` as bad and attach a `DISABLED_` to it -- but it'll also do it to `< test on[...]`, as long as there's any `>` character after it, even though that will never parse as HTML

so a user writing `< 256px` in their post will make every instance of the word `on` after it have a `DISABLED_` next to it. and that is a bad thing

i looked it up to be sure and the HTML specification says that if < is followed by anything other than an ASCII letter, then it will not parse as a tag [(source)](https://www.w3.org/TR/html5/syntax.html#tag-open-state)
