### PR TITLE
Remove the Photobucket filter

### DIFF
--- a/lib/function.php
+++ b/lib/function.php
@@ -1225,7 +1225,7 @@ function dofilters($p){
 		$p=str_replace("-->", '--&gt;</font>', $p);
 	}
 
-	$p=preg_replace("'(https?://.*?photobucket.com/)'si",'images/photobucket.png#\\1',$p);
+	//$p=preg_replace("'(https?://.*?photobucket.com/)'si",'images/photobucket.png#\\1',$p);
 	$p=preg_replace("'http://.{0,3}\.?tinypic\.com'si",'tinyshit',$p);
 	$p=str_replace('<link href="http://pieguy1372.freeweb7.com/misc/piehills.css" rel="stylesheet">',"",$p);
 	$p=str_replace("tabindex=\"0\" ","title=\"the owner of this button is a fucking dumbass\" ",$p);


### PR DESCRIPTION
Photobucket images work fine now:

![Photobucket Image](http://i1109.photobucket.com/albums/h427/Clay_Buster_SMW/cb2-1.png)

I should probably not embed an image that I don't have control over (and could be changed later) but anyway, it shows that Photobucket is not being awful anymore and there's no need for this filter anymore (I hope).