### PR TITLE
more HTML filter fixes

### DIFF
--- a/lib/function.php
+++ b/lib/function.php
@@ -1289,7 +1289,7 @@ function xss_clean($data) {
 	#$data = preg_replace('#(<[^>]+?[\x00-\x20"\'])(?:on|xmlns)[^>]*+>#iu', '$1>', $data);
 	do {
 		$old_data	= $data;
-		$data		= preg_replace('#(<[A-Za-z][^>]*?[\x00-\x20"\'])(on|xmlns)([^>]*+)>#iu', '$1DISABLED_$2$3>', $data);
+		$data		= preg_replace('#(<[A-Za-z][^>]*?[\x00-\x20\x2F"\'])(on|xmlns)[A-Za-z]*=([^>]*+)>#iu', '$1DISABLED_$2$3>', $data);
 	} while ($old_data !== $data);
 
 	// Remove javascript: and vbscript: protocols


### PR DESCRIPTION
Character `\x2F` (a.k.a this one `/`), if placed before an attribute, will actually not invalidate it. This can be used for XSS. It's likely to generate a parse error or to be blocked by the browser, but it's better be safe than sorry.

In order to fix Wario levels of greed, a `[A-Za-z]*=` was added after the `(on|xmlns)` rule. This way it'll only match if it has an equal sign after the attribute name. Attributes that aren't directly followed by an equal sign don't parse as valid attributes, even unquoted ones.

There's still an issue where if you place `on=stuff` inside another harmless attribute like `title` it'll try to disable it as well, but I doubt this can be fixed with a Regex.