### PR TITLE
fix extra <tr> tag

### DIFF
--- a/memberlist.php
+++ b/memberlist.php
@@ -130,9 +130,9 @@
 	$s = $ppp*$page;
 	for($u=0;$u < $ppp;$u++) {
 		$i = $s + $u;
-		$ulist.="<tr style=\"height:24px;\">";
 		$user = $users[$i];
 		if (!$user) break;
+		$ulist.="<tr style=\"height:24px;\">";
 
 		$userpicture='&nbsp';
 		if ($user['minipic'])


### PR DESCRIPTION
if the number of users to display in memberlist.php is less than the max amount per page, it'll create an extra ``<tr>`` tag at the end

this is because it creates the ``<tr>`` tag before it checks if it has run out of users to display